### PR TITLE
Enable AMD/Intel monitor capture

### DIFF
--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -71,7 +71,7 @@ modules:
     sources:
       - type: git
         url: https://repo.dec05eba.com/gpu-screen-recorder
-        commit: c510bc5ae5099640869ae4a9a475339a5593e676
+        commit: c0ebae365d3ee20dc6ed1cf71d998bf040e93149
     modules:
       - name: libXNVCtrl
         no-autogen: true

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -11,6 +11,7 @@ finish-args:
   - --device=dri
   - --share=network
   - --filesystem=host
+  - --talk-name=org.freedesktop.Flatpak
 
 modules:
   - name: ffmpeg
@@ -62,7 +63,7 @@ modules:
     sources:
       - type: git
         url: https://repo.dec05eba.com/gpu-screen-recorder
-        commit: 5ea4e7fff1b332d2c16f8163a50b0b6d81ef23dd
+        commit: c510bc5ae5099640869ae4a9a475339a5593e676
     modules:
       - name: libXNVCtrl
         no-autogen: true
@@ -88,4 +89,4 @@ modules:
     sources:
       - type: git
         url: https://repo.dec05eba.com/gpu-screen-recorder-gtk
-        commit: 13421a8802a7478002556da419852d004558317a
+        commit: dc7b3011a10294dce2be9074c44925f25f1a9a86

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -71,7 +71,7 @@ modules:
     sources:
       - type: git
         url: https://repo.dec05eba.com/gpu-screen-recorder
-        commit: c0ebae365d3ee20dc6ed1cf71d998bf040e93149
+        commit: df2509c0aaf7ce33de48535b03fc677574b93e14
     modules:
       - name: libXNVCtrl
         no-autogen: true

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -71,7 +71,7 @@ modules:
     sources:
       - type: git
         url: https://repo.dec05eba.com/gpu-screen-recorder
-        commit: df2509c0aaf7ce33de48535b03fc677574b93e14
+        commit: 690065da0fa9344c41782aba0a29e38b79c94d84
     modules:
       - name: libXNVCtrl
         no-autogen: true
@@ -103,4 +103,4 @@ modules:
     sources:
       - type: git
         url: https://repo.dec05eba.com/gpu-screen-recorder-gtk
-        commit: dc7b3011a10294dce2be9074c44925f25f1a9a86
+        commit: 403c750333383908999217fda265373c19277b78


### PR DESCRIPTION
Requires the flatpak to be installed system-wide and it requires restricted root access.
Record a single window if you dont like these restrictions.

Depends on https://github.com/flathub/flatpak-builder-lint/pull/133