### PR TITLE
Re-enable opus

### DIFF
--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -105,8 +105,8 @@ modules:
           -DNDEBUG -static -static-libgcc
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r575.3143358.tar.gz
-        sha512: 03a4b05d06d89aee6d21bf93e85a5e26ed66b4f1330dae3319d0de714c2e7d393fc0890da93ed3a4d29e1873e3a9d30de7545c1fb77311750ac7b7cbbcde00e7
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r585.2cd031d.tar.gz
+        sha512: 8438babc9ec5691a95e5f21f613e7e64007222ba5f9326c2b9a0d068c034c36c0d886b69ba9251a66dbf8e16dd9c7f3c07ee3a60496774a399e07b4df109f16a
         strip-components: 0
     modules:
       - name: libXNVCtrl
@@ -165,6 +165,6 @@ modules:
         "$FLATPAK_DEST/share/icons/hicolor/128x128/apps/com.dec05eba.gpu_screen_recorder.png"
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r260.db41355.tar.gz
-        sha512: e0282284d7f967a32df696f683d9128199f47248cad47bfc6ac0b5020ae9b02655553898ca0d8e2f0e407fe2b2f9fb716c3bd74e60f3a06dbf3c27db787b17dd
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r270.a284333.tar.gz
+        sha512: bf30337d41516e87dcfbee3f8be887f7de1f6853d6a3e281dca74688c5d052555d416cafb366eead1d68a611f1b914498aacc6cbaa7127e42f7cc7902d7270f6
         strip-components: 0


### PR DESCRIPTION
Re-enable opus audio codec.
Remove flac audio codec option until it's fixed.
Improve video quality when recording HDR.
Fix flv issues.
Add mpegts container and option to select codec for custom streaming service.