### PR TITLE
Update to version 4.0.0

### DIFF
--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -58,8 +58,8 @@ modules:
           -DNDEBUG -static -static-libgcc
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r681.f9a4104.tar.gz
-        sha512: b1043ee15dc529d003b865c94aa4b7f01479b12cfc55b0ed4fd02261a06dc433a52ec92ebc861ad1246145d2993870ce853ebd9d2da8c99c7fcae3ab5f54c89f
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r682.37107ba.tar.gz
+        sha512: 0a7dfeb482e1e7f078055c7bf0bdab8084c04db35e0e1144f034130dde89823d66e5f3a6c896b5d9c2f88d0d6b52eba49f21d09d357ce866ec07fb4ebb3b33e5
         strip-components: 0
     modules:
       - name: libXNVCtrl

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -146,6 +146,6 @@ modules:
       - update-desktop-database -q "$FLATPAK_DEST/share/applications"
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r345.462a327.tar.gz
-        sha512: 7ea7355fb28a8ceae81a4cbfec5f548299897c185863acb3e8239052f369733f8f011739117c738a26ddea0d75283c8641293f1bc77dc6bdc75ccc6a96e25334
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r346.629fdcd.tar.gz
+        sha512: 8d9dac76fcc4ea6e0efc35efeee8be6175b5077c0d16d82acc54d970f3180f6bfb72d1cb5158d9c669971bafc843cc5488889b2cf1741550e25917a8d1ce9c30
         strip-components: 0

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -116,7 +116,7 @@ modules:
       - ninja -C build
       - strip build/gpu-screen-recorder-gtk
       - install -Dm755 build/gpu-screen-recorder-gtk "$FLATPAK_DEST/bin/gpu-screen-recorder-gtk"
-      - install -Dm644 gpu-screen-recorder-gtk.desktop "$FLATPAK_DEST/share/applications/com.dec05eba.gpu_screen_recorder.desktop"
+      - install -Dm644 com.dec05eba.gpu_screen_recorder.desktop "$FLATPAK_DEST/share/applications/com.dec05eba.gpu_screen_recorder.desktop"
       - install -Dm644 com.dec05eba.gpu_screen_recorder.appdata.xml "$FLATPAK_DEST/share/metainfo/com.dec05eba.gpu_screen_recorder.appdata.xml"
       - install -Dm644 "icons/hicolor/32x32/status/com.dec05eba.gpu_screen_recorder.tray-idle.png"
         "$FLATPAK_DEST/share/icons/hicolor/32x32/status/com.dec05eba.gpu_screen_recorder.tray-idle.png"
@@ -146,6 +146,6 @@ modules:
       - update-desktop-database -q "$FLATPAK_DEST/share/applications"
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r341.7183f6d.tar.gz
-        sha512: fd0bdf686afe29ba21de6ea20a2e926cc88499f52915f414625aabbc5491e2a091d56a980c5952f65b1b1ecf48ef084467b7228cf0538ee1d67babc8ed73122a
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r344.42bfe13.tar.gz
+        sha512: 9a0852f6536b369951bf49a89e34d89db96944c06b9d3da088c1f85079a1c21d2b0d671ca6df7b1cfbf3144a80f5c7d5ec3b870e6ea9ab2f3dc25e8ba9de5082
         strip-components: 0

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -10,7 +10,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.Notifications
@@ -58,8 +58,8 @@ modules:
           -DNDEBUG -static -static-libgcc
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r631.42e5930.tar.gz
-        sha512: b01a9a13e439a022cc835bc810381e8f8ab9b906478e51f425be82cd56134a2cd30603875b7c5cc162bc22a9671002a2c25b3fb5cea4d23c3b99f4850d334a22
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r681.f9a4104.tar.gz
+        sha512: b1043ee15dc529d003b865c94aa4b7f01479b12cfc55b0ed4fd02261a06dc433a52ec92ebc861ad1246145d2993870ce853ebd9d2da8c99c7fcae3ab5f54c89f
         strip-components: 0
     modules:
       - name: libXNVCtrl
@@ -146,6 +146,6 @@ modules:
       - update-desktop-database -q "$FLATPAK_DEST/share/applications"
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r306.dcae815.tar.gz
-        sha512: ad4b5c89df5cb066deb4ef003ca22c22ea30bfc3600961f6132db2552720daae19affe6c5cba239598649eb4fe8d758e79034c25214c2a78b9871ad8848ce277
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r341.7183f6d.tar.gz
+        sha512: fd0bdf686afe29ba21de6ea20a2e926cc88499f52915f414625aabbc5491e2a091d56a980c5952f65b1b1ecf48ef084467b7228cf0538ee1d67babc8ed73122a
         strip-components: 0

--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -58,8 +58,8 @@ modules:
           -DNDEBUG -static -static-libgcc
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r682.37107ba.tar.gz
-        sha512: 0a7dfeb482e1e7f078055c7bf0bdab8084c04db35e0e1144f034130dde89823d66e5f3a6c896b5d9c2f88d0d6b52eba49f21d09d357ce866ec07fb4ebb3b33e5
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder.git.r688.e9343cc.tar.gz
+        sha512: f7f8efe02dae9346e26045411d7ca9c57fd80f6d0422bc9f81c46397700195f316466f8770bd0134ffc5917570fefb7a443fc1ebe518478e2b280e4647b2069c
         strip-components: 0
     modules:
       - name: libXNVCtrl
@@ -146,6 +146,6 @@ modules:
       - update-desktop-database -q "$FLATPAK_DEST/share/applications"
     sources:
       - type: archive
-        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r344.42bfe13.tar.gz
-        sha512: 9a0852f6536b369951bf49a89e34d89db96944c06b9d3da088c1f85079a1c21d2b0d671ca6df7b1cfbf3144a80f5c7d5ec3b870e6ea9ab2f3dc25e8ba9de5082
+        url: https://dec05eba.com/snapshot/gpu-screen-recorder-gtk.git.r345.462a327.tar.gz
+        sha512: 7ea7355fb28a8ceae81a4cbfec5f548299897c185863acb3e8239052f369733f8f011739117c738a26ddea0d75283c8641293f1bc77dc6bdc75ccc6a96e25334
         strip-components: 0

--- a/dependencies/ffmpeg.yml
+++ b/dependencies/ffmpeg.yml
@@ -28,13 +28,13 @@ cleanup:
 sources:
   - type: git
     url: https://git.ffmpeg.org/ffmpeg.git
-    commit: e38092ef9395d7049f871ef4d5411eb410e283e0
-    tag: n6.1.1
+    commit: af25a4bfd2503caf3ee485b27b99b620302f5718
+    tag: n7.0.1
     x-checker-data:
       type: git
       tag-pattern: ^n([\d.]+)$
       versions:
-        <: '7'
+        <: '8'
 modules:
   - name: ffnvcodec
     no-autogen: true


### PR DESCRIPTION
Changes:
Added desktop portal (pipewire) capture option. This fixes issue with glitched capture on certain Intel iGPUS (on Wayland). Added global hotkeys on Wayland. KDE Plasma is the only Wayland environment that supports this properly at the moment. Add separate hotkeys for start and stop and option to show notification when starting/stopping recording. Fix HDR capture (HDR metadata is now correct). Note that HDR capture is only available on Wayland and when recording a monitor without the desktop portal option. Added VP8 and VP9 video codecs if supported by the hardware. Added software encoding option.
Update ffmpeg to version 7.0.1.

Also replace socket=x11 with socket=fallback-x11 (see https://github.com/flathub/flathub/issues/1452)