### PR TITLE
Revert to 24.08

### DIFF
--- a/com.dec05eba.gpu_screen_recorder.yml
+++ b/com.dec05eba.gpu_screen_recorder.yml
@@ -1,6 +1,6 @@
 app-id: com.dec05eba.gpu_screen_recorder
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.ziglang


### PR DESCRIPTION
25.08 doesn't work on older intel devices that need i956_drv_video.so vaapi.